### PR TITLE
Fix short circuit logic in partial commit expand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# [0.3.1](https://github.com/tjtelan/git-meta-rs/compare/v0.3.0...v0.3.1) (2021-02-26)
+- Changed the order of short-circuit checks in `expand_partial_commit_id()` ([#15](https://github.com/tjtelan/git-meta-rs/issues/15))
 # [0.3.0](https://github.com/tjtelan/git-meta-rs/compare/v0.2.1...v0.3.0) (2021-02-14)
 - Changed `with_commit()` to take a commit id. Moved the `git2::Commit` builder to `with_git2_commit()`
 - Changed `with_branch()` to take an `Option<String>`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "git-meta"
 readme = "README.md"
 repository = "https://github.com/tjtelan/git-meta-rs"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 git-url-parse = "^0.3"

--- a/src/info.rs
+++ b/src/info.rs
@@ -282,15 +282,18 @@ impl GitRepo {
 
     /// Takes in a partial commit SHA-1, and attempts to expand to the full 40-char commit id
     pub fn expand_partial_commit_id<S: AsRef<str>>(&self, partial_commit_id: S) -> Result<String> {
+
+        // Don't need to do anything if the commit is already complete
+        // I guess the only issue is not validating it exists. Is that ok?
+        if partial_commit_id.as_ref().len() == 40 {
+            return Ok(partial_commit_id.as_ref().to_string());
+        }
+
         // We can't reliably succeed if repo is a shallow clone
         if self.to_repository()?.is_shallow() {
             return Err(eyre!(
                 "No support for partial commit id expand on shallow clones"
             ));
-        }
-
-        if partial_commit_id.as_ref().len() == 40 {
-            return Ok(partial_commit_id.as_ref().to_string());
         }
 
         let repo = self.to_repository()?;


### PR DESCRIPTION
Full length 40-char commits don't need work
Resolve #15